### PR TITLE
readme: Clean up markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 angular-gettext-cli
 ===================
 
-A command line interface for angular-gettext-tools
+A command line interface for [angular-gettext-tools](https://github.com/rubenv/angular-gettext-tools)
 
 ## Installation
 
@@ -13,6 +13,6 @@ A command line interface for angular-gettext-tools
 `angular-gettext-cli  --files "./app/*.+(js|html)" --dest ./extract.pot --marker-name i18n`
 
 ## Parameters:
-    *. --files - an [glob](https://github.com/isaacs/node-glob) pattern to specify files to process
-    *. --dest - path to file to write extracted words.
-    *. --marker-name - a name of marker to search in js-files (see angular-gettext-tools)
+* `--files` - a [glob](https://github.com/isaacs/node-glob) pattern to specify files to process
+* `--dest` - path to file to write extracted words.
+* `--marker-name` - a name of marker to search in js-files (see [angular-gettext-tools](https://github.com/rubenv/angular-gettext-tools#options))


### PR DESCRIPTION
This adds a link to angular-gettext-tools and fixes the link in the “Parameters:” section.