### PR TITLE
Add support for attributes parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A command line interface for [angular-gettext-tools](https://github.com/rubenv/a
 * `--dest` - path to file to write extracted words.
 * `--marker-name` - (optional) a name of marker to search in js-files (see [angular-gettext-tools](https://github.com/rubenv/angular-gettext-tools#options))
 * `--marker-names` - (optional) comma separated string of marker names to search for in the js-files (see [angular-gettext-tools](https://github.com/rubenv/angular-gettext-tools#options))
+* `--attributes` - (optional) comma separated string of marker names to search for in the html-files (see [angular-gettext-tools](https://github.com/rubenv/angular-gettext-tools#options))
 
 ## Compilation:
 

--- a/bin/gettext
+++ b/bin/gettext
@@ -17,6 +17,10 @@ if (argv.compile) {
     extract(argv);
 }
 
+function strToArray(obj, key, value) {
+    obj[key] = obj[key].replace(/\s/g,'').split(",");
+}
+
 // add obj['markerName'] = obj['marker-name'] etc.
 function objToUpperCase(obj) {
     var keys = Object.keys(obj);
@@ -27,9 +31,10 @@ function objToUpperCase(obj) {
 
         obj[key] = obj[keys[i]];
     }
-    if (obj.markerNames){
-      obj.markerNames = obj.markerNames.replace(/\s/g,'').split(",");
-    }
+
+    obj.markerNames && strToArray(obj, 'markerNames');
+    obj.attributes && strToArray(obj, 'attributes');
+
     return obj;
 }
 

--- a/example/example.html
+++ b/example/example.html
@@ -1,1 +1,2 @@
 <a href="/" translate>Hello {{name}}</a>
+<p custom-i18n>Demo</p>

--- a/example/extract-reference.pot
+++ b/example/extract-reference.pot
@@ -4,6 +4,10 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Project-Id-Version: \n"
 
+#: example/example.html:2
+msgid "Demo"
+msgstr ""
+
 #: example/example.js:2
 msgid "Hello"
 msgstr ""

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "test": "bash acceptance-test.sh",
-    "example-extract": "./bin/gettext --files 'example/*.+(html|js)' --dest example/dist/extract.pot --marker-names 'i18n, __'",
+    "example-extract": "./bin/gettext --files 'example/*.+(html|js)' --dest example/dist/extract.pot --marker-names 'i18n, __' --attributes 'custom-i18n'",
     "example-compile": "./bin/gettext --compile --files 'example/*.po' --dest example/dist/compiled.js --module gettext-test"
   },
   "repository": {


### PR DESCRIPTION
Hey.
Allow us to parse custom attributes inside the HTML, cf the option `"attributes": [],`.
Tests: :ok: 