### PR TITLE
Add positional arguments to the list of files to process

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ A command line interface for [angular-gettext-tools](https://github.com/rubenv/a
 * `--marker-name` - (optional) a name of marker to search in js-files (see [angular-gettext-tools](https://github.com/rubenv/angular-gettext-tools#options))
 * `--marker-names` - (optional) comma separated string of marker names to search for in the js-files (see [angular-gettext-tools](https://github.com/rubenv/angular-gettext-tools#options))
 * `--attributes` - (optional) comma separated string of marker names to search for in the html-files (see [angular-gettext-tools](https://github.com/rubenv/angular-gettext-tools#options))
-* Any remaining positional arguments are added to the list of files to process, in addition to the glob files.
+* Any remaining positional arguments are added to the list of files to process, in addition to the glob files. If the filename starts with @ its contents are read and added to the list of files to process.
 
 ## Compilation:
 
-`angular-gettext-cli  --compile --files 'test/*.po' --dest 'test/output.js' --format javascript --module gettext-test test3.po test4.po`
+`angular-gettext-cli  --compile --files 'test/*.po' --dest 'test/output.js' --format javascript --module gettext-test test3.po test4.po @list.po.in`
 
 ### Parameters:
 * `--files` - a [glob](https://github.com/isaacs/node-glob) pattern to specify files to process

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A command line interface for [angular-gettext-tools](https://github.com/rubenv/a
 
 ## Extraction:
 
-`angular-gettext-cli  --files './app/*.+(js|html)' --exclude '**/*.spec.js' --dest './extract.pot' --marker-name i18n`
+`angular-gettext-cli  --files './app/*.+(js|html)' --exclude '**/*.spec.js' --dest './extract.pot' --marker-name i18n file3.html file4.html`
 
 ### Parameters:
 * `--files` - a [glob](https://github.com/isaacs/node-glob) pattern to specify files to process
@@ -19,15 +19,17 @@ A command line interface for [angular-gettext-tools](https://github.com/rubenv/a
 * `--marker-name` - (optional) a name of marker to search in js-files (see [angular-gettext-tools](https://github.com/rubenv/angular-gettext-tools#options))
 * `--marker-names` - (optional) comma separated string of marker names to search for in the js-files (see [angular-gettext-tools](https://github.com/rubenv/angular-gettext-tools#options))
 * `--attributes` - (optional) comma separated string of marker names to search for in the html-files (see [angular-gettext-tools](https://github.com/rubenv/angular-gettext-tools#options))
+* Any remaining positional arguments are added to the list of files to process, in addition to the glob files.
 
 ## Compilation:
 
-`angular-gettext-cli  --compile --files 'test/*.po' --dest 'test/output.js' --format javascript --module gettext-test`
+`angular-gettext-cli  --compile --files 'test/*.po' --dest 'test/output.js' --format javascript --module gettext-test test3.po test4.po`
 
 ### Parameters:
 * `--files` - a [glob](https://github.com/isaacs/node-glob) pattern to specify files to process
 * `--dest` - path to file to write extracted words.
 * `--format` - `javascript` or `json`. Default is `javascript`
 * `--module` - For the `javascript` output format, the angular module name to use in the output file. Default is `gettext`
+* Any remaining positional arguments are added to the list of files to process, in addition to the glob files.
 
 For more options, see [angular-gettext-tools](https://github.com/rubenv/angular-gettext-tools#options).

--- a/bin/gettext
+++ b/bin/gettext
@@ -3,7 +3,7 @@
 
 var glob = require("glob");
 var fs = require('fs');
-var argv = require('minimist')(process.argv);
+var argv = require('minimist')(process.argv.slice(2));
 var Extractor = require('angular-gettext-tools').Extractor;
 var Compiler = require('angular-gettext-tools').Compiler;
 
@@ -38,55 +38,43 @@ function objToUpperCase(obj) {
     return obj;
 }
 
+function expandFileNames(options) {
+    var globFileNames;
+    if (options.files)
+        globFileNames = glob.sync(options.files, options.exclude ? { ignore: options.exclude } : null);
+    else
+        globFileNames = [];
+    var positionalFileNames = options._;
+    return globFileNames.concat(positionalFileNames);
+}
+
 function compile(options) {
     var gettextCompiler = new Compiler(objToUpperCase(options));
 
+    var fileNames = expandFileNames(options);
     if (options.format && !Compiler.hasFormat(options.format)) {
         throw new Error('There is no "' + options.format + '" output format.');
     }
 
-    var output;
-    glob(options.files, options.exclude ? { ignore: options.exclude } : null, function (err, fileNames) {
-        if (err) {
-            throw err;
-        }
+    var output = gettextCompiler.convertPo(fileNames.map(function(fileName) {
+        return fs.readFileSync(fileName, options.encoding || 'utf-8');
+    }));
 
-        output = gettextCompiler.convertPo(fileNames.map(function(fileName) {
-            return fs.readFileSync(fileName, options.encoding || 'utf-8');
-        }));
-    }).on('end', function finish(fileNames) {
-        console.log('Finished compiling ' + options.files +', read '+fileNames.length+' files.');
-
-        fs.writeFile(options.dest, output, null, function(err) {
-            if (err) {
-              throw err;
-            }
-
-            console.log('All files processed, stored in a file ' + options.dest);
-        });
-    });
+    console.log('Finished compiling, read '+fileNames.length+' files.');
+    fs.writeFileSync(options.dest, output, null);
+    console.log('All files processed, stored in a file ' + options.dest);
 }
 
 function extract(options) {
     var gettextExtractor = new Extractor(objToUpperCase(options));
 
-    glob(options.files, options.exclude ? { ignore: options.exclude } : null, function (err, fileNames) {
-        if (err) {
-            throw err;
-        }
-        fileNames.forEach(function (filename) {
-            var content = fs.readFileSync(filename, 'utf8');
-
-            gettextExtractor.parse(filename, content);
-        });
-    }).on('end', function finish(fileNames) {
-        console.log('Finished parsing ' + options.files +', read '+fileNames.length+' files.');
-
-        fs.writeFile(options.dest, gettextExtractor.toString(), null, function (err) {
-          if (err){
-            throw err;
-          }
-          console.log('All files processed, stored in a file ' + options.dest);
-        });
+    var fileNames = expandFileNames(options);
+    fileNames.forEach(function (filename) {
+        var content = fs.readFileSync(filename, 'utf8');
+        gettextExtractor.parse(filename, content);
     });
+
+    console.log('Finished parsing, read '+fileNames.length+' files.');
+    fs.writeFileSync(options.dest, gettextExtractor.toString(), null);
+    console.log('All files processed, stored in a file ' + options.dest);
 }

--- a/bin/gettext
+++ b/bin/gettext
@@ -45,7 +45,25 @@ function expandFileNames(options) {
     else
         globFileNames = [];
     var positionalFileNames = options._;
-    return globFileNames.concat(positionalFileNames);
+    // Still need to expand @filename -> read content of filename
+    var expandedAt = [];
+    function add(filename) {
+        if (filename)  // ignore empty strings
+            expandedAt.push(filename);
+    }
+    for (let i = 0; i < positionalFileNames.length; i++) {
+        let fileName = positionalFileNames[i];
+        if (fileName[0] !== '@') {
+            // filename does not start with @
+            add(fileName);
+        } else {
+            // filename starts with @, read content
+            let content = fs.readFileSync(fileName.substr(1), options.encoding || 'utf-8').split(/\s+/);
+            for (let j = 0; j < content.length; j++)
+                add(content[j]);
+        }
+    }
+    return globFileNames.concat(expandedAt);
 }
 
 function compile(options) {

--- a/example/extract-reference.pot
+++ b/example/extract-reference.pot
@@ -16,6 +16,10 @@ msgstr ""
 msgid "Hello {{name}}"
 msgstr ""
 
+#: example/positional.htm:1
+msgid "Positional"
+msgstr ""
+
 #: example/example.js:3
 msgid "hi"
 msgstr ""

--- a/example/positional.htm
+++ b/example/positional.htm
@@ -1,0 +1,1 @@
+<a href="/" translate>Positional</a>

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "test": "bash acceptance-test.sh",
-    "example-extract": "./bin/gettext --files 'example/*.+(html|js)' --dest example/dist/extract.pot --marker-names 'i18n, __' --attributes 'custom-i18n'",
+    "example-extract": "./bin/gettext --files 'example/*.+(html|js)' --dest example/dist/extract.pot --marker-names 'i18n, __' --attributes 'custom-i18n' example/positional.htm",
     "example-compile": "./bin/gettext --compile --files 'example/*.po' --dest example/dist/compiled.js --module gettext-test"
   },
   "repository": {


### PR DESCRIPTION
When using with a makefile you have a list of input files but not a glob, so it would be nice if one could pass the files as positional arguments at the end. This is what the branch does; files from glob and positional filenames are concatenated and processed together.